### PR TITLE
Add live build to app

### DIFF
--- a/app/controllers/front_end_builds/builds_controller.rb
+++ b/app/controllers/front_end_builds/builds_controller.rb
@@ -16,7 +16,7 @@ module FrontEndBuilds
 
       if build.save
         build.fetch!
-        build.activate! if build.automatic_activation? and build.is_master?
+        build.activate! if build.automatic_activation? and build.master?
         head :ok
 
       else

--- a/app/controllers/front_end_builds/builds_controller.rb
+++ b/app/controllers/front_end_builds/builds_controller.rb
@@ -16,7 +16,7 @@ module FrontEndBuilds
 
       if build.save
         build.fetch!
-        build.activate! if build.automatic_activation?
+        build.activate! if build.automatic_activation? and build.is_master?
         head :ok
 
       else

--- a/app/controllers/front_end_builds/builds_controller.rb
+++ b/app/controllers/front_end_builds/builds_controller.rb
@@ -16,7 +16,7 @@ module FrontEndBuilds
 
       if build.save
         build.fetch!
-        build.activate! if build.automatic_activiation?
+        build.activate! if build.automatic_activation?
         head :ok
 
       else

--- a/app/models/front_end_builds/app.rb
+++ b/app/models/front_end_builds/app.rb
@@ -49,7 +49,7 @@ module FrontEndBuilds
         name: name,
         api_key: api_key,
         build_ids: recent_builds.map(&:id),
-        best_build_id: (live_build ? live_build.id : nil),
+        live_build_id: (live_build ? live_build.id : nil),
         location: get_url,
         require_manual_activation: require_manual_activation
       }

--- a/app/models/front_end_builds/app.rb
+++ b/app/models/front_end_builds/app.rb
@@ -6,6 +6,7 @@ module FrontEndBuilds
     end
 
     has_many :builds, class_name: 'FrontEndBuilds::Build'
+    has_one :live_build, class_name: 'FrontEndBuilds::Build'
 
     if ActiveRecord::VERSION::MAJOR < 4
       # Rails 3
@@ -42,19 +43,13 @@ module FrontEndBuilds
       self.api_key = SecureRandom.uuid if api_key.blank?
     end
 
-    def find_best_build
-      builds.find_best
-    end
-
     def serialize
-      best = find_best_build
-
       {
         id: id,
         name: name,
         api_key: api_key,
         build_ids: recent_builds.map(&:id),
-        best_build_id: (best ? best.id : nil),
+        best_build_id: (live_build ? live_build.id : nil),
         location: get_url,
         require_manual_activation: require_manual_activation
       }

--- a/app/models/front_end_builds/app.rb
+++ b/app/models/front_end_builds/app.rb
@@ -5,8 +5,8 @@ module FrontEndBuilds
                       :require_manual_activation
     end
 
+    belongs_to :live_build, class_name: 'FrontEndBuilds::Build'
     has_many :builds, class_name: 'FrontEndBuilds::Build'
-    has_one :live_build, class_name: 'FrontEndBuilds::Build'
 
     if ActiveRecord::VERSION::MAJOR < 4
       # Rails 3

--- a/app/models/front_end_builds/build.rb
+++ b/app/models/front_end_builds/build.rb
@@ -68,6 +68,13 @@ module FrontEndBuilds
       save
     end
 
+    def activate!
+      require 'pry'
+      binding.pry
+      app.live_build = self
+      app.save
+    end
+
     def automatic_activiation?
       !app.require_manual_activation?
     end

--- a/app/models/front_end_builds/build.rb
+++ b/app/models/front_end_builds/build.rb
@@ -21,8 +21,7 @@ module FrontEndBuilds
       scope = self
 
       query = {
-        fetched: true,
-        active: true
+        fetched: true
       }
 
       if params[:app]
@@ -37,16 +36,11 @@ module FrontEndBuilds
           )
       end
 
-      # If job or sha is passed in we won't require the
-      # best build to be active. This allows us to smoke
-      # test non active builds
       if params[:sha]
         query[:sha] = params[:sha]
-        query.delete(:active)
 
       elsif params[:job]
         query[:job] = params[:job]
-        query.delete(:active)
 
       elsif params[:branch]
         query[:branch] = params[:branch]
@@ -61,7 +55,7 @@ module FrontEndBuilds
     end
 
     def live?
-      self == app.find_best_build
+      self == app.live_build
     end
 
     def fetch!
@@ -71,11 +65,6 @@ module FrontEndBuilds
 
       self.html = html
       self.fetched = true
-      save
-    end
-
-    def activate!
-      self.active = true
       save
     end
 
@@ -93,7 +82,6 @@ module FrontEndBuilds
         app_id: app_id,
         sha: sha,
         branch: branch,
-        active: active
       }
     end
 

--- a/app/models/front_end_builds/build.rb
+++ b/app/models/front_end_builds/build.rb
@@ -59,6 +59,10 @@ module FrontEndBuilds
       self == app.live_build
     end
 
+    def is_master?
+      branch == 'master'
+    end
+
     def fetch!
       return if fetched?
 

--- a/app/models/front_end_builds/build.rb
+++ b/app/models/front_end_builds/build.rb
@@ -8,7 +8,6 @@ module FrontEndBuilds
                       :endpoint
     end
 
-    has_one :live_app, class_name: "FrontEndBuilds::App", foreign_key: :live_build_id
     belongs_to :app, class_name: "FrontEndBuilds::App"
 
     validates :app, presence: true

--- a/app/models/front_end_builds/build.rb
+++ b/app/models/front_end_builds/build.rb
@@ -64,7 +64,7 @@ module FrontEndBuilds
       self == app.live_build
     end
 
-    def is_master?
+    def master?
       branch == 'master'
     end
 

--- a/app/models/front_end_builds/build.rb
+++ b/app/models/front_end_builds/build.rb
@@ -8,6 +8,7 @@ module FrontEndBuilds
                       :endpoint
     end
 
+    has_one :live_app, class_name: "FrontEndBuilds::App", foreign_key: :live_build_id
     belongs_to :app, class_name: "FrontEndBuilds::App"
 
     validates :app, presence: true
@@ -69,13 +70,11 @@ module FrontEndBuilds
     end
 
     def activate!
-      require 'pry'
-      binding.pry
       app.live_build = self
       app.save
     end
 
-    def automatic_activiation?
+    def automatic_activation?
       !app.require_manual_activation?
     end
 

--- a/app/models/front_end_builds/build.rb
+++ b/app/models/front_end_builds/build.rb
@@ -27,6 +27,7 @@ module FrontEndBuilds
 
       if params[:app]
         query[:app_id] = params[:app].id
+        app = App.find( params[:app].id )
       end
 
       if params[:app_name]
@@ -35,6 +36,7 @@ module FrontEndBuilds
           .where(
             front_end_builds_apps: { name: params[:app_name] }
           )
+        app = App.where( name: params[:app_name] ).first
       end
 
       if params[:sha]
@@ -45,6 +47,9 @@ module FrontEndBuilds
 
       elsif params[:branch]
         query[:branch] = params[:branch]
+
+      elsif app
+        query[:id] = app.live_build_id
 
       end
 

--- a/db/migrate/20150126123348_add_build_ref_to_apps.rb
+++ b/db/migrate/20150126123348_add_build_ref_to_apps.rb
@@ -1,5 +1,5 @@
 class AddBuildRefToApps < ActiveRecord::Migration
   def change
-    add_column :front_end_builds_apps, :best_build_id, :integer
+    add_column :front_end_builds_apps, :live_build_id, :integer
   end
 end

--- a/db/migrate/20150126123348_add_build_ref_to_apps.rb
+++ b/db/migrate/20150126123348_add_build_ref_to_apps.rb
@@ -1,0 +1,5 @@
+class AddBuildRefToApps < ActiveRecord::Migration
+  def change
+    add_column :front_end_builds_apps, :best_build_id, :integer
+  end
+end

--- a/db/migrate/20150127042538_rename_best_build.rb
+++ b/db/migrate/20150127042538_rename_best_build.rb
@@ -1,5 +1,0 @@
-class RenameBestBuild < ActiveRecord::Migration
-  def change
-    rename_column :front_end_builds_apps, :best_build_id, :live_build_id
-  end
-end

--- a/db/migrate/20150127042538_rename_best_build.rb
+++ b/db/migrate/20150127042538_rename_best_build.rb
@@ -1,0 +1,5 @@
+class RenameBestBuild < ActiveRecord::Migration
+  def change
+    rename_column :front_end_builds_apps, :best_build_id, :live_build_id
+  end
+end

--- a/lib/front_end_builds/ext/routes.rb
+++ b/lib/front_end_builds/ext/routes.rb
@@ -6,7 +6,6 @@ module ActionDispatch::Routing
     # Create a front end in your rails router.
     def front_end(name, path = name, options = {})
       defaults = {
-          branch: 'master',
           app_name: name
         }.merge(options)
 

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -6,7 +6,12 @@ module FrontEndBuilds
 
     let(:app) { FactoryGirl.create :front_end_builds_app, name: 'dummy' }
     let!(:builds) { FactoryGirl.create_list :front_end_builds_build, 2, app: app }
-    let!(:live_build) { FactoryGirl.create :front_end_builds_build, :fetched, app: app, live_app: app }
+    let!(:live_build) { FactoryGirl.create :front_end_builds_build, :fetched, app: app }
+
+    before(:each) do
+      app.live_build = live_build
+      app.save
+    end
 
     describe 'index' do
       it "should find all apps" do

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -6,7 +6,7 @@ module FrontEndBuilds
 
     let(:app) { FactoryGirl.create :front_end_builds_app, name: 'dummy' }
     let!(:builds) { FactoryGirl.create_list :front_end_builds_build, 2, app: app }
-    let!(:build) { FactoryGirl.create :front_end_builds_build, :active, :fetched, app: app }
+    let!(:build) { FactoryGirl.create :front_end_builds_build, :fetched, app: app }
 
     describe 'index' do
       it "should find all apps" do

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -25,7 +25,7 @@ module FrontEndBuilds
         expect(response).to be_success
         expect(json['app']['id']).to eq(app.id)
         expect(json['builds'].length).to eq(3)
-        expect(json['app']['best_build_id']). to eq(app.find_best_build.id)
+        expect(json['app']['live_build_id']). to eq(app.live_build.id)
       end
     end
 

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -6,7 +6,7 @@ module FrontEndBuilds
 
     let(:app) { FactoryGirl.create :front_end_builds_app, name: 'dummy' }
     let!(:builds) { FactoryGirl.create_list :front_end_builds_build, 2, app: app }
-    let!(:build) { FactoryGirl.create :front_end_builds_build, :fetched, app: app }
+    let!(:live_build) { FactoryGirl.create :front_end_builds_build, :fetched, app: app, live_app: app }
 
     describe 'index' do
       it "should find all apps" do
@@ -25,7 +25,7 @@ module FrontEndBuilds
         expect(response).to be_success
         expect(json['app']['id']).to eq(app.id)
         expect(json['builds'].length).to eq(3)
-        expect(json['app']['live_build_id']). to eq(app.live_build.id)
+        expect(json['app']['live_build_id']).to eq(app.live_build.id)
       end
     end
 

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -6,12 +6,7 @@ module FrontEndBuilds
 
     let(:app) { FactoryGirl.create :front_end_builds_app, name: 'dummy' }
     let!(:builds) { FactoryGirl.create_list :front_end_builds_build, 2, app: app }
-    let!(:live_build) { FactoryGirl.create :front_end_builds_build, :fetched, app: app }
-
-    before(:each) do
-      app.live_build = live_build
-      app.save
-    end
+    let!(:live_build) { FactoryGirl.create :front_end_builds_build, :live, :fetched, app: app }
 
     describe 'index' do
       it "should find all apps" do

--- a/spec/controllers/front_end_builds/bests_controller_spec.rb
+++ b/spec/controllers/front_end_builds/bests_controller_spec.rb
@@ -13,31 +13,41 @@ module FrontEndBuilds
            branch: 'master',
            html: 'the newest build',
            fetched: true,
-           active: true,
            created_at: 1.day.ago
+       end
+
+       let!(:live) do
+         FactoryGirl.create :front_end_builds_build,
+           app: app,
+           live_app: app,
+           sha: 'sha2',
+           job: 'number2',
+           branch: 'anything',
+           html: 'the live build',
+           fetched: true,
+           created_at: 1.weeks.ago
        end
 
        let!(:older) do
          FactoryGirl.create :front_end_builds_build,
            app: app,
-           sha: 'sha2',
-           job: 'number2',
+           sha: 'sha3',
+           job: 'number3',
            branch: 'master',
            html: 'an old build',
            fetched: true,
-           active: true,
            created_at: 2.weeks.ago
        end
 
-       it "should find the latest build" do
-         get :show, app_name: app.name, branch: 'master'
+       it "should find the live build" do
+         get :show, app_name: app.name
 
          expect(response).to be_success
-         expect(response.body).to match(latest.html)
+         expect(response.body).to match(live.html)
        end
 
        it "should find the build by job" do
-         get :show, app_name: app.name, job: 'number2'
+         get :show, app_name: app.name, job: 'number3'
 
          expect(response).to be_success
          expect(response.body).to match(older.html)

--- a/spec/controllers/front_end_builds/bests_controller_spec.rb
+++ b/spec/controllers/front_end_builds/bests_controller_spec.rb
@@ -17,7 +17,7 @@ module FrontEndBuilds
       end
 
       let!(:live) do
-        FactoryGirl.create :front_end_builds_build,
+        FactoryGirl.create :front_end_builds_build, :live,
           app: app,
           sha: 'sha2',
           job: 'number2',
@@ -36,11 +36,6 @@ module FrontEndBuilds
           html: 'an old build',
           fetched: true,
           created_at: 2.weeks.ago
-      end
-
-      before(:each) do
-        app.live_build = live
-        app.save
       end
 
       it "should find the live build" do

--- a/spec/controllers/front_end_builds/bests_controller_spec.rb
+++ b/spec/controllers/front_end_builds/bests_controller_spec.rb
@@ -4,80 +4,82 @@ module FrontEndBuilds
   RSpec.describe BestsController, :type => :controller do
     let(:app) { FactoryGirl.create :front_end_builds_app, name: 'dummy' }
 
-     describe "show" do
-       let!(:latest) do
-         FactoryGirl.create :front_end_builds_build,
-           app: app,
-           sha: 'sha1',
-           job: 'number1',
-           branch: 'master',
-           html: 'the newest build',
-           fetched: true,
-           created_at: 1.day.ago
-       end
+    describe "show" do
+      let!(:latest) do
+        FactoryGirl.create :front_end_builds_build,
+          app: app,
+          sha: 'sha1',
+          job: 'number1',
+          branch: 'master',
+          html: 'the newest build',
+          fetched: true,
+          created_at: 1.day.ago
+      end
 
-       let!(:live) do
-         FactoryGirl.create :front_end_builds_build,
-           app: app,
-           live_app: app,
-           sha: 'sha2',
-           job: 'number2',
-           branch: 'anything',
-           html: 'the live build',
-           fetched: true,
-           created_at: 1.weeks.ago
-       end
+      let!(:live) do
+        FactoryGirl.create :front_end_builds_build,
+          app: app,
+          sha: 'sha2',
+          job: 'number2',
+          branch: 'anything',
+          html: 'the live build',
+          fetched: true,
+          created_at: 1.weeks.ago
+      end
 
-       let!(:older) do
-         FactoryGirl.create :front_end_builds_build,
-           app: app,
-           sha: 'sha3',
-           job: 'number3',
-           branch: 'master',
-           html: 'an old build',
-           fetched: true,
-           created_at: 2.weeks.ago
-       end
+      let!(:older) do
+        FactoryGirl.create :front_end_builds_build,
+          app: app,
+          sha: 'sha3',
+          job: 'number3',
+          branch: 'master',
+          html: 'an old build',
+          fetched: true,
+          created_at: 2.weeks.ago
+      end
 
-       it "should find the live build" do
-         get :show, app_name: app.name
+      before(:each) do
+        app.live_build = live
+        app.save
+      end
 
-         expect(response).to be_success
-         expect(response.body).to match(live.html)
-       end
+      it "should find the live build" do
+        get :show, app_name: app.name
+        expect(response).to be_success
+        expect(response.body).to match(live.html)
+      end
 
-       it "should find the build by job" do
-         get :show, app_name: app.name, job: 'number3'
+      it "should find the build by job" do
+        get :show, app_name: app.name, job: 'number3'
+        expect(response).to be_success
+        expect(response.body).to match(older.html)
+      end
 
-         expect(response).to be_success
-         expect(response.body).to match(older.html)
-       end
+      context "meta tags" do
+        before(:each) do
+          get :show, app_name: app.name, branch: 'master'
+          expect(response).to be_success
+        end
 
+        subject { response.body }
 
-       context "meta tags" do
-         before(:each) do
-           get :show, app_name: app.name, branch: 'master'
-           expect(response).to be_success
-         end
+        it { should match(/csrf-token/) }
+        it { should match(/front-end-build-version/) }
+        it { should match(/front-end-build-params/) }
+        it { should match(/front-end-build-url/) }
+      end
 
-         subject { response.body }
-         it { should match(/csrf-token/) }
-         it { should match(/front-end-build-version/) }
-         it { should match(/front-end-build-params/) }
-         it { should match(/front-end-build-url/) }
-       end
+      it "should be 404 when nothing is found" do
+        get :show, app_name: 'does-not-exist', branch: 'master'
+        expect(response).to_not be_success
+        expect(response.status).to eq(404)
+      end
 
-       it "should be 404 when nothing is found" do
-         get :show, app_name: 'does-not-exist', branch: 'master'
-         expect(response).to_not be_success
-         expect(response.status).to eq(404)
-       end
+      it "should be able to get the version of the best build" do
+        get :show, app_name: app.name, branch: 'master', format: :json
+        expect(json['version']).to eq(latest.id)
+      end
 
-       it "should be able to get the version of the best build" do
-         get :show, app_name: app.name, branch: 'master', format: :json
-         expect(json['version']).to eq(latest.id)
-       end
-     end
-
+    end
   end
 end

--- a/spec/controllers/front_end_builds/builds_controller_spec.rb
+++ b/spec/controllers/front_end_builds/builds_controller_spec.rb
@@ -48,13 +48,15 @@ module FrontEndBuilds
 
     describe "create" do
       before(:each) do
-        FactoryGirl.create :front_end_builds_build,
+        build = FactoryGirl.create :front_end_builds_build,
           app: app,
-          live_app: app,
           endpoint: 'http://www.ted.com/testing/build',
           created_at: 1.day.ago,
           fetched: true,
           html: 'the old build'
+
+        app.live_build = build
+        app.save
 
         stub_request(
           :get,

--- a/spec/controllers/front_end_builds/builds_controller_spec.rb
+++ b/spec/controllers/front_end_builds/builds_controller_spec.rb
@@ -48,15 +48,12 @@ module FrontEndBuilds
 
     describe "create" do
       before(:each) do
-        build = FactoryGirl.create :front_end_builds_build,
+        FactoryGirl.create :front_end_builds_build, :live,
           app: app,
           endpoint: 'http://www.ted.com/testing/build',
           created_at: 1.day.ago,
           fetched: true,
           html: 'the old build'
-
-        app.live_build = build
-        app.save
 
         stub_request(
           :get,

--- a/spec/controllers/front_end_builds/builds_controller_spec.rb
+++ b/spec/controllers/front_end_builds/builds_controller_spec.rb
@@ -66,6 +66,8 @@ module FrontEndBuilds
       end
 
       it "should create the newest build" do
+        expect(app.live_build.html).to eq('the old build')
+
         post :create, {
           app_name: app.name,
           api_key: app.api_key,
@@ -74,6 +76,7 @@ module FrontEndBuilds
           job: '1',
           endpoint: 'http://www.ted.com/testing/build'
         }
+        app.reload
 
         expect(app.live_build.html).to eq('fetched html')
       end

--- a/spec/controllers/front_end_builds/builds_controller_spec.rb
+++ b/spec/controllers/front_end_builds/builds_controller_spec.rb
@@ -48,13 +48,14 @@ module FrontEndBuilds
 
     describe "create" do
       before(:each) do
-        FactoryGirl.create :front_end_builds_build,
+        oldbuild = FactoryGirl.create :front_end_builds_build,
           app: app,
           endpoint: 'http://www.ted.com/testing/build',
           created_at: 1.day.ago,
-          active: true,
           fetched: true,
           html: 'the old build'
+
+        app.live_build = oldbuild
 
         stub_request(
           :get,

--- a/spec/controllers/front_end_builds/builds_controller_spec.rb
+++ b/spec/controllers/front_end_builds/builds_controller_spec.rb
@@ -75,7 +75,7 @@ module FrontEndBuilds
           endpoint: 'http://www.ted.com/testing/build'
         }
 
-        expect(app.builds.find_best.html).to eq('fetched html')
+        expect(app.live_build.html).to eq('fetched html')
       end
 
       it "should not active a build if the app requires manual activiation" do
@@ -91,7 +91,7 @@ module FrontEndBuilds
         }
 
         expect(response).to be_success
-        expect(app.builds.find_best.html).to eq('the old build')
+        expect(app.live_build.html).to eq('the old build')
       end
 
       it "should error if the api key does not match" do

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150126123348) do
+ActiveRecord::Schema.define(version: 20150127042538) do
 
   create_table "front_end_builds_apps", force: :cascade do |t|
-    t.string   "name",                      limit: 255
-    t.string   "api_key",                   limit: 255
+    t.string   "name"
+    t.string   "api_key"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "require_manual_activation",             default: false
-    t.integer  "best_build_id"
+    t.boolean  "require_manual_activation", default: false
+    t.integer  "live_build_id"
   end
 
   add_index "front_end_builds_apps", ["api_key"], name: "index_front_end_builds_apps_on_api_key"
@@ -27,9 +27,9 @@ ActiveRecord::Schema.define(version: 20150126123348) do
 
   create_table "front_end_builds_builds", force: :cascade do |t|
     t.integer  "app_id"
-    t.string   "sha",        limit: 255
-    t.string   "job",        limit: 255
-    t.string   "branch",     limit: 255
+    t.string   "sha"
+    t.string   "job"
+    t.string   "branch"
     t.text     "html"
     t.boolean  "fetched",                 default: false
     t.boolean  "active",                  default: false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,24 +11,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150114202950) do
+ActiveRecord::Schema.define(version: 20150126123348) do
 
-  create_table "front_end_builds_apps", force: true do |t|
-    t.string   "name"
-    t.string   "api_key"
+  create_table "front_end_builds_apps", force: :cascade do |t|
+    t.string   "name",                      limit: 255
+    t.string   "api_key",                   limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "require_manual_activation", default: false
+    t.boolean  "require_manual_activation",             default: false
+    t.integer  "best_build_id"
   end
 
   add_index "front_end_builds_apps", ["api_key"], name: "index_front_end_builds_apps_on_api_key"
   add_index "front_end_builds_apps", ["name"], name: "index_front_end_builds_apps_on_name"
 
-  create_table "front_end_builds_builds", force: true do |t|
+  create_table "front_end_builds_builds", force: :cascade do |t|
     t.integer  "app_id"
-    t.string   "sha"
-    t.string   "job"
-    t.string   "branch"
+    t.string   "sha",        limit: 255
+    t.string   "job",        limit: 255
+    t.string   "branch",     limit: 255
     t.text     "html"
     t.boolean  "fetched",                 default: false
     t.boolean  "active",                  default: false

--- a/spec/factories/front_end_builds_builds.rb
+++ b/spec/factories/front_end_builds_builds.rb
@@ -12,5 +12,9 @@ FactoryGirl.define do
     trait :fetched do
       fetched true
     end
+
+    # trait :live do
+    #   app.live_build = self
+    # end
   end
 end

--- a/spec/factories/front_end_builds_builds.rb
+++ b/spec/factories/front_end_builds_builds.rb
@@ -12,9 +12,5 @@ FactoryGirl.define do
     trait :fetched do
       fetched true
     end
-
-    trait :active do
-      active true
-    end
   end
 end

--- a/spec/factories/front_end_builds_builds.rb
+++ b/spec/factories/front_end_builds_builds.rb
@@ -13,8 +13,8 @@ FactoryGirl.define do
       fetched true
     end
 
-    # trait :live do
-    #   app.live_build = self
-    # end
+    trait :live do
+      after :create, &:activate!
+    end
   end
 end

--- a/spec/models/front_end_builds/app_spec.rb
+++ b/spec/models/front_end_builds/app_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module FrontEndBuilds
   describe App, :type => :model do
     it { should have_many(:builds) }
-    it { should have_one(:live_build) }
+    it { should belong_to(:live_build) }
     it { should validate_presence_of(:name) }
 
     describe '.register_url / get_url' do

--- a/spec/models/front_end_builds/app_spec.rb
+++ b/spec/models/front_end_builds/app_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 module FrontEndBuilds
   describe App, :type => :model do
     it { should have_many(:builds) }
+    it { should have_one(:live_build) }
     it { should validate_presence_of(:name) }
 
     describe '.register_url / get_url' do
@@ -27,36 +28,6 @@ module FrontEndBuilds
         before(:each) { app.save }
         subject { app.api_key }
         it { should_not be_nil }
-      end
-    end
-
-    describe '#find_best_build' do
-      let(:app) { FactoryGirl.create :front_end_builds_app }
-
-      let!(:latest) do
-        FactoryGirl.create :front_end_builds_build,
-          app: app,
-          sha: 'sha1',
-          job: 'number1',
-          branch: 'master',
-          fetched: true,
-          active: true,
-          created_at: 1.day.ago
-      end
-
-      let!(:older) do
-        FactoryGirl.create :front_end_builds_build,
-          app: app,
-          sha: 'sha2',
-          job: 'number2',
-          branch: 'master',
-          fetched: true,
-          active: true,
-          created_at: 2.weeks.ago
-      end
-
-      it "should find the best build" do
-        expect(app.find_best_build).to eq(latest)
       end
     end
 

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -122,6 +122,28 @@ module FrontEndBuilds
       end
     end 
 
+    describe :is_master? do
+      let(:app) { FactoryGirl.create(:front_end_builds_app) }
+      let(:build1) do
+        FactoryGirl.create :front_end_builds_build,
+          app: app,
+          branch: 'master'
+      end
+      let(:build2) do
+        FactoryGirl.create :front_end_builds_build,
+          app: app,
+          branch: 'feature'
+      end
+
+      it "should be truthy if the branch is 'master'" do
+        expect(build1.is_master?).to be_truthy
+      end
+
+      it "should be false if the branch is not 'master'" do
+        expect(build2.is_master?).to be_falsey
+      end
+    end 
+
     describe :fetch! do
       let(:app) do
         FactoryGirl.create(:front_end_builds_app)

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -95,6 +95,7 @@ module FrontEndBuilds
       let!(:latest) do
         FactoryGirl.create :front_end_builds_build,
           app: app,
+          live_app: app,
           sha: 'sha1',
           job: 'number1',
           branch: 'master',
@@ -112,11 +113,11 @@ module FrontEndBuilds
           created_at: 2.weeks.ago
       end
 
-      it "should be live if it's the best" do
+      it "should be live if it's the live build" do
         expect(latest.live?).to be_truthy
       end
 
-      it "should not be live the best if it's not the best" do
+      it "should not be live if it's not the live build" do
         expect(older.live?).to be_falsey
       end
     end 

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -26,7 +26,6 @@ module FrontEndBuilds
       let!(:live_build) do
         FactoryGirl.create :front_end_builds_build,
           app: app,
-          live_app: app,
           sha: 'sha2',
           job: 'number2',
           branch: 'anything',
@@ -42,6 +41,11 @@ module FrontEndBuilds
           branch: 'master',
           fetched: true,
           created_at: 2.weeks.ago
+      end
+
+      before(:each) do
+        app.live_build = live_build
+        app.save
       end
 
       context "with no query" do
@@ -120,7 +124,6 @@ module FrontEndBuilds
       let!(:latest) do
         FactoryGirl.create :front_end_builds_build,
           app: app,
-          live_app: app,
           sha: 'sha1',
           job: 'number1',
           branch: 'master',
@@ -136,6 +139,11 @@ module FrontEndBuilds
           branch: 'master',
           fetched: true,
           created_at: 2.weeks.ago
+      end
+      
+      before(:each) do
+        app.live_build = latest
+        app.save
       end
 
       it "should be live if it's the live build" do

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -147,7 +147,7 @@ module FrontEndBuilds
       end
     end 
 
-    describe :is_master? do
+    describe :master? do
       let(:app) { FactoryGirl.create(:front_end_builds_app) }
       let(:build1) do
         FactoryGirl.create :front_end_builds_build,
@@ -161,11 +161,11 @@ module FrontEndBuilds
       end
 
       it "should be truthy if the branch is 'master'" do
-        expect(build1.is_master?).to be_truthy
+        expect(build1.master?).to be_truthy
       end
 
       it "should be false if the branch is not 'master'" do
-        expect(build2.is_master?).to be_falsey
+        expect(build2.master?).to be_falsey
       end
     end 
 

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -24,7 +24,7 @@ module FrontEndBuilds
       end
 
       let!(:live_build) do
-        FactoryGirl.create :front_end_builds_build,
+        FactoryGirl.create :front_end_builds_build, :live,
           app: app,
           sha: 'sha2',
           job: 'number2',
@@ -41,11 +41,6 @@ module FrontEndBuilds
           branch: 'master',
           fetched: true,
           created_at: 2.weeks.ago
-      end
-
-      before(:each) do
-        app.live_build = live_build
-        app.save
       end
 
       context "with no query" do
@@ -122,7 +117,7 @@ module FrontEndBuilds
     describe :live? do
       let(:app) { FactoryGirl.create(:front_end_builds_app) }
       let!(:latest) do
-        FactoryGirl.create :front_end_builds_build,
+        FactoryGirl.create :front_end_builds_build, :live,
           app: app,
           sha: 'sha1',
           job: 'number1',
@@ -139,11 +134,6 @@ module FrontEndBuilds
           branch: 'master',
           fetched: true,
           created_at: 2.weeks.ago
-      end
-      
-      before(:each) do
-        app.live_build = latest
-        app.save
       end
 
       it "should be live if it's the live build" do

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -23,14 +23,39 @@ module FrontEndBuilds
           created_at: 1.day.ago
       end
 
+      let!(:live_build) do
+        FactoryGirl.create :front_end_builds_build,
+          app: app,
+          live_app: app,
+          sha: 'sha2',
+          job: 'number2',
+          branch: 'anything',
+          fetched: true,
+          created_at: 1.week.ago
+      end
+
       let!(:older) do
         FactoryGirl.create :front_end_builds_build,
           app: app,
-          sha: 'sha2',
-          job: 'number2',
+          sha: 'sha3',
+          job: 'number3',
           branch: 'master',
           fetched: true,
           created_at: 2.weeks.ago
+      end
+
+      context "with no query" do
+        before(:each) do
+          FactoryGirl.create :front_end_builds_build,
+            app: app,
+            sha: 'sha4',
+            branch: 'nonmaster',
+            fetched: true,
+            created_at: 2.days.ago
+        end
+
+        subject { Build.find_best(live_app: app) }
+        it { should eq(live_build) }
       end
 
       context "when finding the branch" do
@@ -48,12 +73,12 @@ module FrontEndBuilds
       end
 
       context "when finding the job" do
-        subject { Build.find_best(app: app, job: 'number2') }
+        subject { Build.find_best(app: app, job: 'number3') }
         it { should eq(older) }
       end
 
       context "when finding the sha" do
-        subject { Build.find_best(app: app, sha: 'sha2') }
+        subject { Build.find_best(app: app, sha: 'sha3') }
         it { should eq(older) }
       end
 

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -54,7 +54,7 @@ module FrontEndBuilds
             created_at: 2.days.ago
         end
 
-        subject { Build.find_best(live_app: app) }
+        subject { Build.find_best(app: app) }
         it { should eq(live_build) }
       end
 

--- a/spec/models/front_end_builds/build_spec.rb
+++ b/spec/models/front_end_builds/build_spec.rb
@@ -20,7 +20,6 @@ module FrontEndBuilds
           job: 'number1',
           branch: 'master',
           fetched: true,
-          active: true,
           created_at: 1.day.ago
       end
 
@@ -31,11 +30,19 @@ module FrontEndBuilds
           job: 'number2',
           branch: 'master',
           fetched: true,
-          active: true,
           created_at: 2.weeks.ago
       end
 
       context "when finding the branch" do
+        before(:each) do
+          FactoryGirl.create :front_end_builds_build,
+            app: app,
+            sha: 'sha3',
+            branch: 'master',
+            fetched: true,
+            created_at: 2.days.ago
+        end
+
         subject { Build.find_best(app: app, branch: 'master') }
         it { should eq(latest) }
       end
@@ -43,21 +50,6 @@ module FrontEndBuilds
       context "when finding the job" do
         subject { Build.find_best(app: app, job: 'number2') }
         it { should eq(older) }
-      end
-
-      context "when finding and active branch" do
-        before(:each) do
-          FactoryGirl.create :front_end_builds_build,
-            app: app,
-            sha: 'sha3',
-            branch: 'master',
-            fetched: true,
-            active: false,
-            created_at: 1.minute.ago
-        end
-
-        subject { Build.find_best(app: app, branch: 'master') }
-        it { should eq(latest) }
       end
 
       context "when finding the sha" do
@@ -85,7 +77,6 @@ module FrontEndBuilds
             sha: 'sha4',
             branch: 'master',
             fetched: true,
-            active: true,
             created_at: 1.minute.ago
         end
 
@@ -108,7 +99,6 @@ module FrontEndBuilds
           job: 'number1',
           branch: 'master',
           fetched: true,
-          active: true,
           created_at: 1.day.ago
       end
 
@@ -119,7 +109,6 @@ module FrontEndBuilds
           job: 'number2',
           branch: 'master',
           fetched: true,
-          active: true,
           created_at: 2.weeks.ago
       end
 

--- a/spec/requests/api_requests_spec.rb
+++ b/spec/requests/api_requests_spec.rb
@@ -4,10 +4,14 @@ describe 'It should not intercept API requests', type: :request do
   let!(:build) do
     FactoryGirl.create(:front_end_builds_build,
       app: front_end_app,
-      live_app: front_end_app,
       fetched: true,
       active: true
     )
+  end
+
+  before(:each) do
+    front_end_app.live_build = build
+    front_end_app.save
   end
 
   it "should get the build" do

--- a/spec/requests/api_requests_spec.rb
+++ b/spec/requests/api_requests_spec.rb
@@ -4,6 +4,7 @@ describe 'It should not intercept API requests', type: :request do
   let!(:build) do
     FactoryGirl.create(:front_end_builds_build,
       app: front_end_app,
+      live_app: front_end_app,
       fetched: true,
       active: true
     )

--- a/spec/requests/api_requests_spec.rb
+++ b/spec/requests/api_requests_spec.rb
@@ -2,16 +2,11 @@ describe 'It should not intercept API requests', type: :request do
   let(:front_end_app) { FactoryGirl.create :front_end_builds_app, name: "dummy" }
 
   let!(:build) do
-    FactoryGirl.create(:front_end_builds_build,
+    FactoryGirl.create(:front_end_builds_build, :live,
       app: front_end_app,
       fetched: true,
       active: true
     )
-  end
-
-  before(:each) do
-    front_end_app.live_build = build
-    front_end_app.save
   end
 
   it "should get the build" do

--- a/spec/requests/new_build_version_spec.rb
+++ b/spec/requests/new_build_version_spec.rb
@@ -7,7 +7,7 @@ describe "Front end builds new version", type: :request do
   before(:each) do
     FactoryGirl.create(
       :front_end_builds_build,
-      :active, :fetched,
+      :fetched,
       app: front_end_app,
     )
 


### PR DESCRIPTION
@ryanto ready for review. Big changes:

- Builds don't have a concept of being active/inactive. I stripped out `active` from everywhere.
- "Activating a build" means making it live i.e. make it the build that's served up at the public URL
- Builds are automatically activated if (a) they're master and (b) the app allows automatic activation [link](https://github.com/tedconf/front_end_builds/pull/48/files#diff-b3d99933ec1d08027e9922d464f00875L19).
- The relationship modeling is a bit funky.

    Originally I wanted `App` to `have_many` builds and also to `have_one` `live_build`, but it didn't work. (Reason: modeled like this, I couldn't create an App that had a normal build but no a live one. [note I added the `live_build_id` to the apps table]. Apparently `has_one` is sugar for `has_many` `limit 1`, which makes sense why this wasn't working.)

    So, [I followed the advice here](http://stackoverflow.com/a/6536356/1406664) and modeled it so an `App` `has_many` builds, but `belongs_to` a `live_build`. See the relationships [here](https://github.com/tedconf/front_end_builds/pull/48/files#diff-fdfdb1e5fdfc5bd9b7ee244c652b2cf4R11) and [here](https://github.com/tedconf/front_end_builds/pull/48/files#diff-df49d247bc8aef28f257f2be47178aa7R8).

- With that, the defaults for `bests_controller` is now just the `app_name` (no more `branch: master`), and if no other query params are specified `Build.find_best` just returns the live build for the app.

- And FYI the admin still needs to be updated