### PR TITLE
Use middleware to serve assets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.5.1)
     multi_json (1.10.1)
-    nokogiri (1.6.6.1)
+    nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pry (0.10.1)
       coderay (~> 1.1.0)

--- a/lib/front_end_builds/engine.rb
+++ b/lib/front_end_builds/engine.rb
@@ -1,3 +1,5 @@
+require 'front_end_builds/middleware/admin_assets'
+
 module FrontEndBuilds
   class Engine < ::Rails::Engine
     isolate_namespace FrontEndBuilds
@@ -10,7 +12,7 @@ module FrontEndBuilds
     end
 
     initializer "static assets" do |app|
-      app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public")
+      app.middleware.use(FrontEndBuilds::Middleware::AdminAssets, "#{root}/public")
     end
   end
 end

--- a/lib/front_end_builds/middleware/admin_assets.rb
+++ b/lib/front_end_builds/middleware/admin_assets.rb
@@ -1,0 +1,29 @@
+require 'rack/utils'
+require 'active_support/core_ext/uri'
+require 'action_dispatch/middleware/static'
+
+module FrontEndBuilds::Middleware
+
+  class AdminAssets < ::ActionDispatch::Static
+    def front_end_build_asset_regex
+      @_regex ||= /^\/front_end_builds\/assets\//
+    end
+
+    def requesting_feb_assets?(path)
+      path.match(front_end_build_asset_regex)
+    end
+
+    def call(env)
+      path = env['PATH_INFO']
+
+      # Only call Static middleware if we know this is a request for
+      # a front end build asset.
+      if requesting_feb_assets?(path)
+        super
+      else
+        @app.call(env)
+      end
+    end
+
+  end
+end

--- a/spec/requests/admin_assets_spec.rb
+++ b/spec/requests/admin_assets_spec.rb
@@ -1,0 +1,19 @@
+describe 'I should be able to access the admin assets', type: :request do
+  let(:admin_javascript_file_disk) do
+    Dir["public/front_end_builds/assets/admin-*.js"].first
+  end
+
+  let(:admin_javascript_url) do
+    admin_javascript_file_disk.gsub(/^public/, '')
+  end
+
+  let(:admin_javascript_content) do
+    File.read(admin_javascript_file_disk)
+  end
+
+  it 'should return the js file' do
+    get admin_javascript_url
+    expect(response).to be_success
+    expect(response.body).to eq(admin_javascript_content)
+  end
+end


### PR DESCRIPTION
Switch away from using ActionDispatch::Static with our own middleware
that just wraps Static.

Reason being that ActionDispatch::Static will check to see if there is a
file on disk for each request. If there is a file, it will serve it,
otherwise it will continue down the middleware stack. This is great for
development mode, but is bad for a high req/s production environment if
every http request needs to check disk.

This is a simple fix to that problem. Since we want to use the
middleware to serve our assets, but don't want to do a ``File.exists?``
call every request we will first verify that the request is for a
front end build admin area asset. If it is, we handoff to
ActionDispatch::Static, otherwise continue down the middleware stack.

This should give us the best of both worlds.

cc @samselikoff 