### PR TITLE
Simplify handling of params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ matrix:
       env: "RAILS_VERSION=4.2.0"
     - rvm: 2.2.0
       env: "RAILS_VERSION=3.2.0"
+  include:
+    - rvm: 2.2.2
+      env: "RAILS_VERSION=5.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -8,16 +8,9 @@ rails = case rails_version
 when 'master'
   { :github => 'rails/rails'}
 when 'default'
-  '~> 4.2.0'
+  '~> 5.0.4'
 else
   "~> #{rails_version}"
 end
 
 gem 'rails', rails
-
-# These no longer ship with ruby 2.2.0, but are needed for
-# Rails 3 and 4.0.0
-if RUBY_VERSION == "2.2.0"
-  gem 'test-unit'
-  gem 'minitest'
-end

--- a/app/controllers/front_end_builds/admin_controller.rb
+++ b/app/controllers/front_end_builds/admin_controller.rb
@@ -15,7 +15,7 @@ module FrontEndBuilds
       html = html.sub('BASEURL/', baseURL)
       html = html.sub("baseURL: ''", "baseURL: '#{baseURL}'")
 
-      render text: html
+      render plain: html
     end
 
   end

--- a/app/controllers/front_end_builds/application_controller.rb
+++ b/app/controllers/front_end_builds/application_controller.rb
@@ -1,11 +1,6 @@
 module FrontEndBuilds
   class ApplicationController < ActionController::Base
 
-    def use_params(param_method)
-      v = Rails::VERSION::MAJOR
-      send("#{param_method}_rails_#{v}")
-    end
-
     # Public: A quick helper to create a respond_to block for
     # returning json to the client. Used because `respond_with`
     # is no longer included in Rails.
@@ -21,5 +16,10 @@ module FrontEndBuilds
       respond_with_json({ errors: errors }, status: status)
     end
 
+    private
+
+    def supports_strong_params?
+      Rails::VERSION::MAJOR >= 4
+    end
   end
 end

--- a/app/controllers/front_end_builds/application_controller.rb
+++ b/app/controllers/front_end_builds/application_controller.rb
@@ -15,11 +15,5 @@ module FrontEndBuilds
     def error!(errors, status = :unprocessable_entity)
       respond_with_json({ errors: errors }, status: status)
     end
-
-    private
-
-    def supports_strong_params?
-      Rails::VERSION::MAJOR >= 4
-    end
   end
 end

--- a/app/controllers/front_end_builds/apps_controller.rb
+++ b/app/controllers/front_end_builds/apps_controller.rb
@@ -2,7 +2,7 @@ require_dependency "front_end_builds/application_controller"
 
 module FrontEndBuilds
   class AppsController < ApplicationController
-    before_filter :set_app , :only => [:show, :destroy, :update]
+    before_action :set_app , :only => [:show, :destroy, :update]
 
     def index
       apps = App.includes(:recent_builds)

--- a/app/controllers/front_end_builds/apps_controller.rb
+++ b/app/controllers/front_end_builds/apps_controller.rb
@@ -6,7 +6,6 @@ module FrontEndBuilds
 
     def index
       apps = App.includes(:recent_builds)
-
       respond_with_json({
         apps: apps.map(&:serialize),
         builds: apps.map(&:recent_builds)
@@ -61,7 +60,7 @@ module FrontEndBuilds
         )
       else
         respond_with_json(
-          {errors: @app.errors},
+          { errors: @app.errors },
           status: :unprocessable_entity
         )
       end
@@ -74,29 +73,17 @@ module FrontEndBuilds
     end
 
     def app_create_params
-      if supports_strong_params?
-        params.require(:app).permit(
-          :name
-        )
-      else
-        params[:app].slice(:name)
-      end
+      params.require(:app).permit(
+        :name
+      )
     end
 
     def app_update_params
-      if supports_strong_params?
-        params.require(:app).permit(
-          :name,
-          :require_manual_activation,
-          :live_build_id
-        )
-      else
-        params[:app].slice(
-          :name,
-          :require_manual_activation,
-          :live_build_id
-        )
-      end
+      params.require(:app).permit(
+        :name,
+        :require_manual_activation,
+        :live_build_id
+      )
     end
   end
 end

--- a/app/controllers/front_end_builds/apps_controller.rb
+++ b/app/controllers/front_end_builds/apps_controller.rb
@@ -23,7 +23,7 @@ module FrontEndBuilds
     end
 
     def create
-      @app = FrontEndBuilds::App.new( use_params(:app_create_params) )
+      @app = FrontEndBuilds::App.new( app_create_params )
 
       if @app.save
         respond_with_json(
@@ -39,7 +39,7 @@ module FrontEndBuilds
     end
 
     def update
-      if @app.update_attributes( use_params(:app_update_params) )
+      if @app.update_attributes( app_update_params )
 
         respond_with_json(
           { app: @app.serialize },
@@ -73,33 +73,30 @@ module FrontEndBuilds
       @app = FrontEndBuilds::App.find(params[:id])
     end
 
-    def app_create_params_rails_3
-      params[:app].slice(:name)
+    def app_create_params
+      if supports_strong_params?
+        params.require(:app).permit(
+          :name
+        )
+      else
+        params[:app].slice(:name)
+      end
     end
 
-    def app_create_params_rails_4
-      params.require(:app).permit(
-        :name
-      )
+    def app_update_params
+      if supports_strong_params?
+        params.require(:app).permit(
+          :name,
+          :require_manual_activation,
+          :live_build_id
+        )
+      else
+        params[:app].slice(
+          :name,
+          :require_manual_activation,
+          :live_build_id
+        )
+      end
     end
-    alias_method :app_create_params_rails_5, :app_create_params_rails_4
-
-    def app_update_params_rails_3
-      params[:app].slice(
-        :name,
-        :require_manual_activation,
-        :live_build_id
-      )
-    end
-
-    def app_update_params_rails_4
-      params.require(:app).permit(
-        :name,
-        :require_manual_activation,
-        :live_build_id
-      )
-    end
-    alias_method :app_update_params_rails_5, :app_update_params_rails_4
-
   end
 end

--- a/app/controllers/front_end_builds/bests_controller.rb
+++ b/app/controllers/front_end_builds/bests_controller.rb
@@ -11,7 +11,7 @@ module FrontEndBuilds
   class BestsController < ApplicationController
     include Rails.application.routes.url_helpers
 
-    before_filter :find_front_end, only: [:show]
+    before_action :find_front_end, only: [:show]
 
     def show
       if @front_end

--- a/app/controllers/front_end_builds/bests_controller.rb
+++ b/app/controllers/front_end_builds/bests_controller.rb
@@ -16,12 +16,12 @@ module FrontEndBuilds
     def show
       if @front_end
         respond_to do |format|
-          format.html { render text: @front_end.with_head_tag(meta_tags) }
+          format.html { render plain: @front_end.with_head_tag(meta_tags) }
           format.json { render json: { version: @front_end.id } }
         end
       else
         # TODO install instructions, user needs to push build
-        render text: "not found", status: 404
+        render plain: "not found", status: 404
       end
     end
 

--- a/app/controllers/front_end_builds/bests_controller.rb
+++ b/app/controllers/front_end_builds/bests_controller.rb
@@ -52,11 +52,7 @@ module FrontEndBuilds
     end
 
     def build_search_params
-      if supports_strong_params?
-        params.permit(:app_name, :id, :branch, :sha, :job)
-      else
-        params.slice(:app_name, :id, :branch, :sha, :job)
-      end
+      params.permit(:app_name, :id, :branch, :sha, :job)
     end
   end
 end

--- a/app/controllers/front_end_builds/bests_controller.rb
+++ b/app/controllers/front_end_builds/bests_controller.rb
@@ -33,10 +33,10 @@ module FrontEndBuilds
         csrf_param: request_forgery_protection_token,
         csrf_token: form_authenticity_token,
         front_end_build_version: @front_end.id,
-        front_end_build_params: use_params(:build_search_params).to_query,
+        front_end_build_params: build_search_params.to_h.to_query,
         front_end_build_url: front_end_builds_best_path(
-            use_params(:build_search_params).merge(format: :json)
-          )
+          build_search_params.merge(format: :json)
+        )
       }
 
       tags
@@ -48,17 +48,15 @@ module FrontEndBuilds
     end
 
     def find_front_end
-      @front_end = FrontEndBuilds::Build.find_best(use_params(:build_search_params))
+      @front_end = FrontEndBuilds::Build.find_best(build_search_params)
     end
 
-    def build_search_params_rails_3
-      params.slice(:app_name, :id, :branch, :sha, :job)
+    def build_search_params
+      if supports_strong_params?
+        params.permit(:app_name, :id, :branch, :sha, :job)
+      else
+        params.slice(:app_name, :id, :branch, :sha, :job)
+      end
     end
-
-    def build_search_params_rails_4
-      params.permit(:app_name, :id, :branch, :sha, :job)
-    end
-    alias_method :build_search_params_rails_5, :build_search_params_rails_4
-
   end
 end

--- a/app/controllers/front_end_builds/builds_controller.rb
+++ b/app/controllers/front_end_builds/builds_controller.rb
@@ -22,7 +22,7 @@ module FrontEndBuilds
         build.errors[:base] << 'No access - invalid SSH key' if !build.verify
 
         render(
-          text: 'Could not create the build: ' + build.errors.full_messages.to_s,
+          plain: 'Could not create the build: ' + build.errors.full_messages.to_s,
           status: :unprocessable_entity
         )
       end
@@ -45,7 +45,7 @@ module FrontEndBuilds
 
       if @app.nil?
         render(
-          text: "No app named #{params[:app_name]}.",
+          plain: "No app named #{params[:app_name]}.",
           status: :unprocessable_entity
         )
 
@@ -65,11 +65,7 @@ module FrontEndBuilds
     end
 
     def build_create_params
-      if supports_strong_params?
-        params.permit(*_create_params)
-      else
-        params.slice(*_create_params)
-      end
+      params.permit(*_create_params)
     end
   end
 end

--- a/app/controllers/front_end_builds/builds_controller.rb
+++ b/app/controllers/front_end_builds/builds_controller.rb
@@ -2,7 +2,7 @@ require_dependency "front_end_builds/application_controller"
 
 module FrontEndBuilds
   class BuildsController < ApplicationController
-    before_filter :set_app!, only: [:create]
+    before_action :set_app!, only: [:create]
 
     def index
       builds = FrontEndBuilds::Build.where(app_id: params[:app_id])

--- a/app/controllers/front_end_builds/builds_controller.rb
+++ b/app/controllers/front_end_builds/builds_controller.rb
@@ -12,7 +12,7 @@ module FrontEndBuilds
     end
 
     def create
-      build = @app.builds.new(use_params(:build_create_params))
+      build = @app.builds.new(build_create_params)
 
       if build.verify && build.save
         build.setup!
@@ -64,14 +64,12 @@ module FrontEndBuilds
       ]
     end
 
-    def build_create_params_rails_3
-      params.slice(*_create_params)
+    def build_create_params
+      if supports_strong_params?
+        params.permit(*_create_params)
+      else
+        params.slice(*_create_params)
+      end
     end
-
-    def build_create_params_rails_4
-      params.permit(*_create_params)
-    end
-    alias_method :build_create_params_rails_5, :build_create_params_rails_4
-
   end
 end

--- a/app/controllers/front_end_builds/pubkeys_controller.rb
+++ b/app/controllers/front_end_builds/pubkeys_controller.rb
@@ -8,8 +8,7 @@ module FrontEndBuilds
     end
 
     def create
-      pubkey = FrontEndBuilds::Pubkey
-        .new( pubkey_create_params )
+      pubkey = FrontEndBuilds::Pubkey.new(pubkey_create_params)
 
       if pubkey.save
         respond_with_json(
@@ -37,14 +36,10 @@ module FrontEndBuilds
     private
 
     def pubkey_create_params
-      if supports_strong_params?
-        params.require(:pubkey).permit(
-          :name,
-          :pubkey
-        )
-      else
-        params[:pubkey].slice(:name, :pubkey)
-      end
+      params.require(:pubkey).permit(
+        :name,
+        :pubkey
+      )
     end
   end
 end

--- a/app/controllers/front_end_builds/pubkeys_controller.rb
+++ b/app/controllers/front_end_builds/pubkeys_controller.rb
@@ -9,7 +9,7 @@ module FrontEndBuilds
 
     def create
       pubkey = FrontEndBuilds::Pubkey
-        .new( use_params(:pubkey_create_params) )
+        .new( pubkey_create_params )
 
       if pubkey.save
         respond_with_json(
@@ -36,17 +36,15 @@ module FrontEndBuilds
 
     private
 
-    def pubkey_create_params_rails_3
-      params[:pubkey].slice(:name, :pubkey)
+    def pubkey_create_params
+      if supports_strong_params?
+        params.require(:pubkey).permit(
+          :name,
+          :pubkey
+        )
+      else
+        params[:pubkey].slice(:name, :pubkey)
+      end
     end
-
-    def pubkey_create_params_rails_4
-      params.require(:pubkey).permit(
-        :name,
-        :pubkey
-      )
-    end
-    alias_method :pubkey_create_params_rails_5, :pubkey_create_params_rails_4
-
   end
 end

--- a/front_end_builds.gemspec
+++ b/front_end_builds.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'factory_girl_rails'
+  s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-stack_explorer'
   s.add_development_dependency 'shoulda-matchers', '2.7.0'

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -4,9 +4,9 @@ module FrontEndBuilds
   RSpec.describe AppsController, :type => :controller do
     routes { FrontEndBuilds::Engine.routes }
 
-    let(:app) { FactoryGirl.create :front_end_builds_app, name: 'dummy' }
-    let!(:builds) { FactoryGirl.create_list :front_end_builds_build, 2, app: app }
-    let!(:live_build) { FactoryGirl.create :front_end_builds_build, :live, :fetched, app: app }
+    let(:app) { FactoryGirl.create(:front_end_builds_app, name: 'dummy') }
+    let!(:builds) { FactoryGirl.create_list(:front_end_builds_build, 2, app: app) }
+    let!(:live_build) { FactoryGirl.create(:front_end_builds_build, :live, :fetched, app: app) }
 
     describe 'index' do
       it "should find all apps" do
@@ -20,7 +20,7 @@ module FrontEndBuilds
 
     describe 'show' do
       it "should find the requested app" do
-        get :show, id: app.id, format: :json
+        get :show, params: { id: app.id }, format: :json
 
         expect(response).to be_success
         expect(json['app']['id']).to eq(app.id)
@@ -31,8 +31,10 @@ module FrontEndBuilds
 
     describe 'create' do
       it "should create a new app" do
-        post :create, app: {
-            name: 'my-new-app'
+        post :create, params: {
+            app: {
+              name: 'my-new-app'
+            }
           },
           format: :json
 
@@ -50,9 +52,11 @@ module FrontEndBuilds
 
       it "should edit an existing app" do
         post :update,
-          id: app.id,
-          app: {
-            live_build_id: new_build.id
+          params: {
+            id: app.id,
+            app: {
+              live_build_id: new_build.id
+            }
           },
           format: :json
 
@@ -71,7 +75,9 @@ module FrontEndBuilds
       context 'a valid app' do
         before(:each) do
           post :destroy,
-            id: deletable_app.id,
+            params: {
+              id: deletable_app.id
+            },
             format: :json
         end
 

--- a/spec/controllers/front_end_builds/bests_controller_spec.rb
+++ b/spec/controllers/front_end_builds/bests_controller_spec.rb
@@ -39,32 +39,32 @@ module FrontEndBuilds
       end
 
       it "should find the live build" do
-        get :show, app_name: app.name
+        get :show, params: { app_name: app.name }
         expect(response).to be_success
         expect(response.body).to match(live.html)
       end
 
       it "should find the build by job" do
-        get :show, app_name: app.name, job: 'number3'
+        get :show, params: { app_name: app.name, job: 'number3' }
         expect(response).to be_success
         expect(response.body).to match(older.html)
       end
 
       it "should find the build by build_id" do
-        get :show, id: older.id
+        get :show, params: { id: older.id }
         expect(response).to be_success
         expect(response.body).to match(older.html)
       end
 
       it "should find the build by branch" do
-        get :show, app_name: app.name, branch: 'master'
+        get :show, params: { app_name: app.name, branch: 'master' }
         expect(response).to be_success
         expect(response.body).to match(latest.html)
       end
 
       context "meta tags" do
         before(:each) do
-          get :show, app_name: app.name, branch: 'master'
+          get :show, params: { app_name: app.name, branch: 'master' }
           expect(response).to be_success
         end
 
@@ -77,13 +77,13 @@ module FrontEndBuilds
       end
 
       it "should be 404 when nothing is found" do
-        get :show, app_name: 'does-not-exist', branch: 'master'
+        get :show, params: { app_name: 'does-not-exist', branch: 'master' }
         expect(response).to_not be_success
         expect(response.status).to eq(404)
       end
 
       it "should be able to get the version of the best build" do
-        get :show, app_name: app.name, branch: 'master', format: :json
+        get :show, params: { app_name: app.name, branch: 'master', format: :json }
         expect(json['version']).to eq(latest.id)
       end
 

--- a/spec/controllers/front_end_builds/builds_controller_spec.rb
+++ b/spec/controllers/front_end_builds/builds_controller_spec.rb
@@ -10,7 +10,7 @@ module FrontEndBuilds
       it "should list all the builds for an app" do
         FactoryGirl.create_list(:front_end_builds_build, 3, app: app)
 
-        get :index, app_id: app.id, format: :json
+        get :index, params: { app_id: app.id }, format: :json
         expect(response).to be_success
         expect(json['builds'].length).to eq(3)
       end
@@ -19,7 +19,7 @@ module FrontEndBuilds
         build1 = FactoryGirl.create(:front_end_builds_build, app: app)
         FactoryGirl.create(:front_end_builds_build)
 
-        get :index, app_id: app.id, format: :json
+        get :index, params: { app_id: app.id }, format: :json
         expect(response).to be_success
         expect(json['builds'].length).to eq(1)
         expect(json['builds'].first['id']).to eq(build1.id)
@@ -40,7 +40,7 @@ module FrontEndBuilds
       let(:build) { FactoryGirl.create :front_end_builds_build }
 
       it "should load the app" do
-        get :show, id: build.id, format: :json
+        get :show, params: { id: build.id }, format: :json
         expect(response).to be_success
         expect(json['build']['id']).to eq(build.id)
       end
@@ -66,7 +66,7 @@ module FrontEndBuilds
       it "should create the new build, and make it live" do
         expect(app.live_build.html).to eq('the old build')
 
-        post :create, {
+        post :create, params: {
           app_name: app.name,
           branch: 'master',
           sha: 'some-sha',
@@ -82,7 +82,7 @@ module FrontEndBuilds
       it "should not make a new build live if it's non-master" do
         expect(app.live_build.html).to eq('the old build')
 
-        post :create, {
+        post :create, params: {
           app_name: app.name,
           branch: 'some-feature',
           sha: 'some-sha',
@@ -98,7 +98,7 @@ module FrontEndBuilds
       it "should not active a build if the app requires manual activiation" do
         app.update_attributes(require_manual_activation: true)
 
-        post :create, {
+        post :create, params: {
           app_name: app.name,
           branch: 'master',
           sha: 'some-sha',
@@ -114,7 +114,7 @@ module FrontEndBuilds
       it 'should error if the app cannot be found' do
         app.update_attributes(require_manual_activation: true)
 
-        post :create, {
+        post :create, params: {
           app_name: 'this-does-not-exist',
           branch: 'master',
           sha: 'some-sha',
@@ -132,7 +132,7 @@ module FrontEndBuilds
         digest = OpenSSL::Digest::SHA256.new
         signature = pkey.sign(digest, "#{app.name}-#{endpoint}")
 
-        post :create, {
+        post :create, params: {
           app_name: app.name,
           branch: 'master',
           sha: 'some-sha',
@@ -146,7 +146,7 @@ module FrontEndBuilds
       end
 
       it "should error if not all fields are present" do
-        post :create, {
+        post :create, params: {
           app_name: app.name,
           endpoint: endpoint,
           signature: create_signature("#{app.name}-#{endpoint}")
@@ -156,7 +156,7 @@ module FrontEndBuilds
       end
 
       it 'should let the html be submitted' do
-        post :create, {
+        post :create, params: {
           app_name: app.name,
           branch: 'master',
           sha: 'some-sha',

--- a/spec/controllers/front_end_builds/host_apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/host_apps_controller_spec.rb
@@ -6,7 +6,7 @@ module FrontEndBuilds
 
     describe 'show' do
       it 'should fetch info about the host application (rails)' do
-        get :show, id: 'current', format: :json
+        get :show, params: { id: 'current' }, format: :json
 
         expect(response).to be_success
         expect(json['host_app']['id']).to eq('current')

--- a/spec/controllers/front_end_builds/pubkeys_controller_spec.rb
+++ b/spec/controllers/front_end_builds/pubkeys_controller_spec.rb
@@ -18,9 +18,11 @@ module FrontEndBuilds
     describe 'create' do
       it 'should create a new pubkey' do
         post :create,
-          pubkey: {
-            name: 'my-new-key',
-            pubkey: 'asdfasdf'
+          params: {
+            pubkey: {
+              name: 'my-new-key',
+              pubkey: 'asdfasdf'
+            }
           },
           format: :json
 
@@ -36,8 +38,10 @@ module FrontEndBuilds
 
       it 'should not create a new pubkey without a pubkey' do
         post :create,
-          pubkey: {
-            name: 'my-new-key'
+          params: {
+            pubkey: {
+              name: 'my-new-key'
+            }
           },
           format: :json
 
@@ -50,7 +54,7 @@ module FrontEndBuilds
       let(:pubkey) { FactoryGirl.create(:front_end_builds_pubkey) }
 
       it 'should remove a pubkey' do
-        delete :destroy, id: pubkey.id, format: :json
+        delete :destroy, params: { id: pubkey.id }, format: :json
 
         expect(response).to be_success
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -14,12 +14,9 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  if Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR > 1
-    config.serve_static_files = true
-  else
-    config.serve_static_assets  = true
-  end
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.enabled = true
+
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require 'rspec/its'
 require 'factory_girl_rails'
 require 'shoulda/matchers'
 require 'webmock/rspec'
+require 'database_cleaner'
 
 Rails.backtrace_cleaner.remove_silencers!
 

--- a/spec/requests/build_spec.rb
+++ b/spec/requests/build_spec.rb
@@ -13,11 +13,13 @@ describe "Front end builds API", type: :request do
 
   it "creates a new build and then uses it" do
     post "/dummy",
-      branch: "master",
-      sha: "a1b2c3",
-      job: "jenkins-build-1",
-      endpoint: endpoint,
-      signature: create_signature("dummy-#{endpoint}")
+      params: {
+        branch: "master",
+        sha: "a1b2c3",
+        job: "jenkins-build-1",
+        endpoint: endpoint,
+        signature: create_signature("dummy-#{endpoint}")
+      }
 
     expect(response).to be_success
 
@@ -34,12 +36,14 @@ describe "Front end builds API", type: :request do
 
   it "should be able to create a build from a generic endpoint" do
     post "/front_end_builds/builds",
-      app_name: 'dummy',
-      branch: "master",
-      sha: "a1b2c3",
-      job: "jenkins-build-1",
-      endpoint: endpoint,
-      signature: create_signature("dummy-#{endpoint}")
+      params: {
+        app_name: 'dummy',
+        branch: "master",
+        sha: "a1b2c3",
+        job: "jenkins-build-1",
+        endpoint: endpoint,
+        signature: create_signature("dummy-#{endpoint}")
+      }
 
     expect(response).to be_success
     expect(front_end_app.builds.length).to eq(1)

--- a/spec/requests/new_build_version_spec.rb
+++ b/spec/requests/new_build_version_spec.rb
@@ -4,6 +4,7 @@ describe "Front end builds new version", type: :request do
   let(:front_end_app) { FactoryGirl.create :front_end_builds_app, name: "dummy" }
   let(:version_url) { "/front_end_builds/best?app_name=dummy&branch=master" }
   let(:endpoint) { "http://www.ted.com/builds/1" }
+  let(:headers) { { 'ACCEPT' => 'application/json' } }
 
   before(:each) do
     FactoryGirl.create(
@@ -20,23 +21,25 @@ describe "Front end builds new version", type: :request do
 
   it "gets a different version when a new build is created" do
     # get the current version
-    get version_url, format: :json
+    get version_url, headers: headers
     expect(response).to be_success
     expect(json['version']).to_not be_nil
 
     original_version = json['version']
 
     post "/dummy",
-      branch: "master",
-      sha: "a1b2c3",
-      job: "jenkins-build-1",
-      endpoint: endpoint,
-      signature: create_signature("dummy-#{endpoint}")
+      params: {
+        branch: "master",
+        sha: "a1b2c3",
+        job: "jenkins-build-1",
+        endpoint: endpoint,
+        signature: create_signature("dummy-#{endpoint}")
+      }
 
     expect(response).to be_success
 
     # now we should get a new version
-    get version_url, format: :json
+    get version_url, headers: headers
     expect(response).to be_success
     expect(json['version']).to_not be_nil
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
Replace the version specific methods with something that will probably require less maintenance. And works for Rails 5.
