### PR TITLE
don't require an authenticity token when posting

### DIFF
--- a/app/controllers/front_end_builds/application_controller.rb
+++ b/app/controllers/front_end_builds/application_controller.rb
@@ -1,5 +1,6 @@
 module FrontEndBuilds
   class ApplicationController < ActionController::Base
+    skip_before_action :verify_authenticity_token
 
     # Public: A quick helper to create a respond_to block for
     # returning json to the client. Used because `respond_with`


### PR DESCRIPTION
not sure how ember-cli would generate an authenticity token, but we're unable to deploy some TED frontends with this filter in place.

application is rails 5.2.2.1. it appears that ember builds the frontend and successfully uploads it to S3, but then rails rejects the update with a 422 error.

airbrake says we're posting

```
{
      "app_name": "talkstar",
      "branch": "master",
      "endpoint": "https://s3.amazonaws.com/talkstar-frontend/dist-778d321a0d1f0d50ee3d0f037129a8a15115afc6/index.html",
      "sha": "778d321a0d1f0d50ee3d0f037129a8a15115afc6",
      "signature": "...snip..."
    }
```