### PR TITLE
Update build.js

### DIFF
--- a/admin/app/models/build.js
+++ b/admin/app/models/build.js
@@ -17,7 +17,7 @@ export default DS.Model.extend({
   },
 
   shortSha: function() {
-    return this.get('sha').slice(0, 7);
+    return (this.get('sha') || "unknown sha").slice(0, 7);
   }.property('sha'),
 
   location: function() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19894032/71922365-05a00180-3148-11ea-97af-a862c84e78bf.png)

EMS `/frontends` is broken in staging and prod due to a sha not being defined. This is a low hanging fruit fix to see if this at least loads the page.

https://ems.ted.com/frontends/
https://ems-staging.ted.com/frontends/