### PR TITLE
Fix issue for Rails apps with lots of Frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's new
 
+### 1.0.2 (January 9th, 2020)
+* This version fixes a bug with FrontEndBuilds::AppsController#index where it would not show the `/frontends`.
+ - This bug was introduced in 1.0.0 (rails 5 updates).
+ - The controller should return "10 builds for each app", instead it was
+   returning "10 builds for all apps". This and issue when one of your apps has
+   a really old "live build" that is older than your 10 most recent (for any app)
+
 ### 1.0.1 (May 6th, 2019)
 * `FrontEndBuilds::App.live_build` is now optional. This resolves issues with  Rails 5 clients that have `Rails.application.config.active_record.belongs_to_required_by_default` enabled.
 

--- a/app/controllers/front_end_builds/apps_controller.rb
+++ b/app/controllers/front_end_builds/apps_controller.rb
@@ -5,7 +5,13 @@ module FrontEndBuilds
     before_action :set_app , :only => [:show, :destroy, :update]
 
     def index
-      apps = App.includes(:recent_builds)
+      # this should be the most recent 10 builds for each app
+
+      # DO NOT use `App.includes(:recent_builds)`
+      # b/c it mucks up the grouping logic and only gives the most
+      # recent 10 for ALL apps not 10 per app
+      apps = App.all
+
       respond_with_json({
         apps: apps.map(&:serialize),
         builds: apps.map(&:recent_builds)

--- a/front_end_builds.gemspec
+++ b/front_end_builds.gemspec
@@ -36,6 +36,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'shoulda-matchers', '2.7.0'
+  # These 2 are needed so that the rails app version matches
+  # otherwise bundle gives you sprockets 4
+  s.add_development_dependency 'sprockets', '3.7.2'
+  s.add_development_dependency 'sprockets-rails', '3.2.1'
   s.add_development_dependency "sqlite3"
   s.add_development_dependency 'webmock'
 end

--- a/lib/front_end_builds/version.rb
+++ b/lib/front_end_builds/version.rb
@@ -1,3 +1,3 @@
 module FrontEndBuilds
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -17,7 +17,7 @@ module FrontEndBuilds
         expect(json['builds'].length).to eq(3)
       end
 
-      # This specs query composition b/c it changed slightled between rails 4 and rails 5
+      # This specs query composition b/c it changed slightly between rails 4 and rails 5
       # in regards to includes
       describe "testing query composition", focus: true do
         # getting rid of the ones from the outer describe

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -16,6 +16,36 @@ module FrontEndBuilds
         expect(json['apps'].length).to eq(1)
         expect(json['builds'].length).to eq(3)
       end
+
+      # This specs query composition b/c it changed slightled between rails 4 and rails 5
+      # in regards to includes
+      describe "testing query composition", focus: true do
+        # getting rid of the ones from the outer describe
+        before(:each) do
+          App.delete_all
+          Build.delete_all
+        end
+
+        let(:app1) { create(:front_end_builds_app, name: 'dummy') }
+        let(:app2) { create(:front_end_builds_app, name: 'dummy2') }
+        let!(:app1_builds) { create_list(:front_end_builds_build, 1, app: app1) }
+        let!(:app2_builds) { create_list(:front_end_builds_build, 10, app: app2) }
+
+        it "Finds the correct builds_ids for EACH app" do
+          get :index, format: :json
+
+          expect(response).to be_success
+          expect(json['apps'].length).to eq(2)
+          app1_json = json['apps'].select{|x| x['id'] == app1.id}.first
+          app2_json = json['apps'].select{|x| x['id'] == app2.id}.first
+
+          # make sure the oldest app (by created_by) shows up
+          # this rows ends up missing if include(:recent_builds) is in the Arel
+          expect(app1_json['build_ids']).to match(app1_builds.map(&:id))
+
+          expect(app2_json['build_ids']).to match( app2.recent_builds.map(&:id))
+        end
+      end
     end
 
     describe 'show' do


### PR DESCRIPTION
The FrontendBuildsAppController#index action is supposed to return 10 recent builds for every app.  

During the rails 5 upgrades for this gem a bit of group by logic was was missed .   

Initially report via: https://github.com/tedconf/front_end_builds/pull/87

I've added a failing spec and made the suggested changes in #87 by @tlball 

This issue would only impact cases where a single rails app as many frontends and there are more than 11 total builds. In this setup the if one of the apps "live build" was older than the 10th  `/frontends` (the admin interface) won't render b/c one of the "live builds" isn't found in the apps build_ids JSON property.


CC: @nickcoyne 
