### PR TITLE
Push TED-specific updates to our private server

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_GEM__PUSH_KEY: "rubygems_ted_com"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.bundle/
 log/*.log
 pkg/
 spec/dummy/db/*.sqlite3

--- a/front_end_builds.gemspec
+++ b/front_end_builds.gemspec
@@ -5,6 +5,15 @@ require "front_end_builds/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
+  # Prevent pushing this gem to RubyGems.org.
+  # allow pushing only to our private gem server.
+  if s.respond_to?(:metadata)
+    s.metadata['allowed_push_host'] = 'https://rubygems.ted.com/private'
+  else
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
+  end
+
   s.name        = "front_end_builds"
   s.version     = FrontEndBuilds::VERSION
   s.authors     = ["Ryan Toronto", "Sam Selikoff", "John Hirbour"]
@@ -24,6 +33,7 @@ Gem::Specification.new do |s|
   # for ssh key bits, but it doesn't support OpenSSL v2.x
 
   # sort this by alpha
+  s.add_development_dependency 'bundler', '>=1.15.0'
   s.add_development_dependency 'bundler-audit'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
We need to make some minor updates to this gem for TED's internal projects. Those releases will not be publicly released. 

This PR configures this gem to push to TED's private gem server.